### PR TITLE
feature/KAS-1425 model refactor: Activity

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,8 +34,8 @@ app.get('/getSubcasePhases', async (req, res) => {
     
     if (activityUris && activityUris.length > 0 ) {
       syncforeach(activityUris, (next, activityUri, index, array) => {
-        var addEventsAndStuff;
-        (addEventsAndStuff = async function(){
+        var getPhases;
+        (getPhases = async function(){
           const result = await repository.getPhasesOfActivities(activityUri.activity, activityUri.subcase);
 
           if ((parseInt(activityUri.totalAgendaitems) == 1) && (result[0].agendaStatus == DESIGN_AGENDA_STATUS)) {

--- a/app.js
+++ b/app.js
@@ -32,7 +32,7 @@ app.get('/getSubcasePhases', async (req, res) => {
   try {
     const activityUris = await repository.queryActivitiesOfSubcase(subcaseId);
     
-    if (activityUris && activityUris.length > 1 ) {
+    if (activityUris && activityUris.length > 0 ) {
       syncforeach(activityUris, (next, activityUri, index, array) => {
         var addEventsAndStuff;
         (addEventsAndStuff = async function(){

--- a/app.js
+++ b/app.js
@@ -5,21 +5,55 @@ const app = mu.app;
 const bodyParser = require('body-parser');
 const repository = require('./repository');
 const cors = require('cors');
+const syncforeach = require('sync-foreach');
+const DESIGN_AGENDA_STATUS = 'http://kanselarij.vo.data.gift/id/agendastatus/2735d084-63d1-499f-86f4-9b69eb33727f'
 
 app.use(bodyParser.json({ type: 'application/*+json' }));
 app.use(cors());
 
-app.get('/', (req, res) => {
-    return getPostponedSubcases(req, res, true);
+app.get('/getPostponedSubcases', async (req, res) => {
+  try {
+    const subcases = await repository.getPostponedSubcases();
+    res.header('Content-Type', 'application/vnd.api+json');
+    res.send({ data: subcases });
+  } catch (error) {
+    console.error(error);
+    res.send({ status: ok, statusCode: 500, body: { error } });
+  }
 });
 
-const getPostponedSubcases = async (req, res) => {
-    try {
-        const subcases = await repository.getPostponedSubcases();
-        res.header('Content-Type', 'application/vnd.api+json');
-        res.send({ data: subcases });
-    } catch (error) {
-        console.error(error);
-        res.send({ status: ok, statusCode: 500, body: { error } });
+app.get('/getSubcasePhases', async (req, res) => {
+  const subcaseId  = req.query.subcaseId;
+  if(!subcaseId){
+    res.send({statusCode: 400, body: 'subcaseId missing'});
+    return;
+  }
+
+  try {
+    const activityUris = await repository.queryActivitiesOfSubcase(subcaseId);
+    
+    if (activityUris && activityUris.length > 1 ) {
+      syncforeach(activityUris, (next, activityUri, index, array) => {
+        var addEventsAndStuff;
+        (addEventsAndStuff = async function(){
+          const result = await repository.getPhasesOfActivities(activityUri.activity, activityUri.subcase);
+
+          if ((parseInt(activityUri.totalAgendaitems) == 1) && (result[0].agendaStatus == DESIGN_AGENDA_STATUS)) {
+            // Do nothing, there should not be phaseData for this activity since it does not have an agendaitem on an approved agenda
+          } else {
+            result.sort((a,b) => a.agendaNumber < b.agendaNumber); // We want the latest agenda first in the list
+            array[index].phaseData = result[0];
+          }
+          next();
+      })();
+    }).done(() => {
+        res.send({statusCode: 200, body: activityUris});
+    })
+    } else {
+      res.send({statusCode: 400, body: 'subcaseId has no activities'});
     }
-};
+  } catch (e) {
+    console.log('error', e);
+    res.send({statusCode: 500, body: 'something went wrong while getting the phases of subcase', e});
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,14 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@lblod/mu-auth-sudo": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@lblod/mu-auth-sudo/-/mu-auth-sudo-0.2.0.tgz",
-      "integrity": "sha512-70YkeUY0WdzeU+vBLkLnQsDNIFS5VCBo2Pha6hp/qJAZfQSTwFj32EtKXHA479oDNb3Yeuyzv7TuyW00tEfDCw==",
-      "requires": {
-        "sparql-client-2": "git+https://github.com/erikap/node-sparql-client.git#b7bb3ac76a3708ca2c6d4a04af226df3c71ce95d"
-      }
-    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -21,57 +13,10 @@
         "negotiator": "0.6.1"
       }
     },
-    "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-      "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-    },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "body-parser": {
       "version": "1.18.3",
@@ -95,19 +40,6 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -128,11 +60,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
     "cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -140,14 +67,6 @@
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
@@ -158,16 +77,6 @@
         "ms": "2.0.0"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "denodeify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
-      "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE="
-    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -177,15 +86,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -244,26 +144,6 @@
         "vary": "~1.1.2"
       }
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
     "finalhandler": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -278,21 +158,6 @@
         "unpipe": "~1.0.0"
       }
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -303,28 +168,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      }
-    },
     "http-errors": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -334,16 +177,6 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": ">= 1.4.0 < 2"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -363,52 +196,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -463,11 +250,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
       "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -491,16 +273,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "promise-nodeify": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/promise-nodeify/-/promise-nodeify-0.1.0.tgz",
-      "integrity": "sha1-SgC4I3U31TUkDMZmXCR7R8qESXA="
-    },
     "proxy-addr": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
@@ -509,16 +281,6 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
-    },
-    "psl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
-      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA=="
-    },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -539,33 +301,6 @@
         "http-errors": "1.6.3",
         "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
-      }
-    },
-    "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
       }
     },
     "safe-buffer": {
@@ -614,65 +349,15 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
-    "sparql-client-2": {
-      "version": "git+https://github.com/erikap/node-sparql-client.git#b7bb3ac76a3708ca2c6d4a04af226df3c71ce95d",
-      "from": "git+https://github.com/erikap/node-sparql-client.git",
-      "requires": {
-        "denodeify": "^1.2.1",
-        "lodash": "^4.0.1",
-        "promise-nodeify": "^0.1.0",
-        "request": "^2.40.0"
-      }
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
-    "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    "sync-foreach": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sync-foreach/-/sync-foreach-1.0.2.tgz",
+      "integrity": "sha512-Y89oRtZ3rmHGM7wuUjgYopi9ttOU8wd2WcP9Ss10Jd16oWQcVi7b6xixTC14dI653Jrens3M6Wzg+2IgdBBPCg=="
     },
     "type-is": {
       "version": "1.6.16",
@@ -688,38 +373,15 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "app.js",
   "dependencies": {
     "body-parser": "^1.18.3",
+    "cors": "^2.8.5",
     "express": "^4.16.4",
     "moment": "^2.23.0",
-    "cors": "^2.8.5",
-    "node-fetch": "^2.3.0"
+    "node-fetch": "^2.3.0",
+    "sync-foreach": "^1.0.2"
   },
   "devDependencies": {},
   "scripts": {

--- a/repository/index.js
+++ b/repository/index.js
@@ -1,7 +1,6 @@
 import mu from 'mu';
 
 const getPostponedSubcases = async () => {
-
     const query = `
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
@@ -9,9 +8,9 @@ const getPostponedSubcases = async () => {
       
       SELECT ?id WHERE { 
           ?subcase a dbpedia:UnitOfWork ;
-            mu:uuid ?id ;
-            besluitvorming:vindtPlaatsTijdens ?activity .
+            mu:uuid ?id .
           ?activity a besluitvorming:Agendering .
+          ?activity besluitvorming:vindtPlaatsTijdens ?subcase .
           ?activity besluitvorming:genereertAgendapunt ?agendapunt .
             
           ?agendapunt besluitvorming:ingetrokken ?retracted . 

--- a/repository/index.js
+++ b/repository/index.js
@@ -1,27 +1,20 @@
 import mu from 'mu';
-const targetGraph = "http://mu.semte.ch/graphs/organizations/kanselarij";
 
 const getPostponedSubcases = async () => {
 
     const query = `
-       PREFIX vo-org: <https://data.vlaanderen.be/ns/organisatie#>
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-      PREFIX vo-gen: <https://data.vlaanderen.be/ns/generiek#> 
-      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
       PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
-      PREFIX agenda: <http://data.lblod.info/id/agendas/>
-      PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
-      PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX dbpedia: <http://dbpedia.org/ontology/>  
       
-      SELECT ?id  
-        WHERE { 
-          GRAPH <${targetGraph}>
-          {
-            ?subcase besluitvorming:isGeagendeerdVia ?agendapunt ;
-             mu:uuid ?id .
-            ?agendapunt ext:heeftVerdaagd ?verdaagd .
-           }
+      SELECT ?id WHERE { 
+          ?subcase a dbpedia:UnitOfWork ;
+            mu:uuid ?id ;
+            besluitvorming:vindtPlaatsTijdens ?activity .
+          ?activity besluitvorming:genereertAgendapunt ?agendapunt .
+            
+          ?agendapunt besluitvorming:ingetrokken ?retracted . 
+          FILTER(?retracted ="true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>)  
       } GROUP BY ?subcase`;
 
     let data = await mu.query(query);

--- a/repository/index.js
+++ b/repository/index.js
@@ -11,6 +11,7 @@ const getPostponedSubcases = async () => {
           ?subcase a dbpedia:UnitOfWork ;
             mu:uuid ?id ;
             besluitvorming:vindtPlaatsTijdens ?activity .
+          ?activity a besluitvorming:Agendering .
           ?activity besluitvorming:genereertAgendapunt ?agendapunt .
             
           ?agendapunt besluitvorming:ingetrokken ?retracted . 


### PR DESCRIPTION
# :mag:  KAS-1425: Model refactor: activity model gebruiken
De refactor verlegt de relatie tussen procedurstap en agendaitem naar een tussenobject: de agendering-activiteit
Bij de refactor hoort ook een deel opkuis van: postponed, procedurestapfases en fasecodes.

## ✏️  What has changed

### app.js:
Aanpassen/verbeteren van bestaande API call
toevoegen API call voor opvragen van de fases van een subcase.

backstory: een agendaitem dat voor een eerste keer op een ontwerpagenda stond had enkel de fase 'ingediend',
na goedkeuren in deze service moesten we dan een nieuwe fase aanmaken 'geagendeerd'
Bij uitstellen kreeg deze de fase 'uitgesteld'
Bij goedkeuren van een beslissing kreeg deze de fase 'beslist'

Deze fases worden nu afgeleid van de agendering-activiteit:
Bestaat de activiteit ? => 'ingediend'
Heeft de activiteit een agendaitem op een goedgekeurde agenda? => 'geagendeerd'
Heeft de activiteit een geagendeerd agendaitem met retracted == true ? (enkel kijken naar de laatste versie van de agenda) => 'uitgesteld'
Heeft de activiteit van een geagendeerd agendaitem een subcase met een beslissing met approved = true ? 'beslist'

De verwerking van de lijst die we hier opbouwen zit in de frontend

### repository/index.js:
Toevoegen nieuwe methodes om de fase lijst op te bouwen

